### PR TITLE
Android support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,19 +4,28 @@ fn main() {
     }
 }
 
-#[cfg(feature = "always-supported")]
+#[cfg(all(feature = "always-supported", not(target_os = "android")))]
 fn supported() -> bool {
     true
 }
 
-#[cfg(feature = "always-fallback")]
+#[cfg(all(feature = "always-fallback", not(target_os = "android")))]
 fn supported() -> bool {
     false
+}
+
+#[cfg(target_os = "android")]
+fn supported() -> bool {
+    cc::Build::new()
+        .file("src/linux-musl.c")
+        .compile("linux-musl");
+    true
 }
 
 #[cfg(not(any(
     feature = "always-supported",
     feature = "always-fallback",
+    target_os = "android",
 )))]
 fn supported() -> bool {
     use std::process::Command;

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn supported() -> bool {
 
 #[cfg(target_os = "android")]
 fn supported() -> bool {
+    panic!("debug!");
     cc::Build::new()
         .file("src/linux-musl.c")
         .compile("linux-musl");
@@ -33,9 +34,7 @@ fn supported() -> bool {
     let dir = tempfile::tempdir().unwrap();
     let test_c = dir.path().join("test.c");
 
-    let compiler = cc::Build::new()
-        .cargo_metadata(false)
-        .get_compiler();
+    let compiler = cc::Build::new().cargo_metadata(false).get_compiler();
     let compiler_path = compiler.path();
     let target = std::env::var("TARGET").unwrap();
 
@@ -43,15 +42,18 @@ fn supported() -> bool {
     // argument types are as expected.
 
     if target.contains("linux") {
-        std::fs::write(&test_c, b"
+        std::fs::write(
+            &test_c,
+            b"
             void renameat2();
             void statfs();
 
             int main() {
                 renameat2();
                 statfs();
-            }"
-        ).unwrap();
+            }",
+        )
+        .unwrap();
 
         let status = Command::new(compiler_path)
             .current_dir(dir.path())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,9 @@ fn rename_exclusive_non_atomic(from: &Path, to: &Path) -> Result<()> {
     std::fs::rename(from, to)
 }
 
-#[cfg(all(target_os = "linux", linker))]
+#[cfg(all(any(target_os = "linux", target_os = "android"), linker))]
 mod linux;
-#[cfg(all(target_os = "linux", linker))]
+#[cfg(all(any(target_os = "linux", target_os = "android"), linker))]
 use linux as sys;
 
 #[cfg(target_vendor = "apple")]
@@ -192,7 +192,7 @@ mod windows;
 use windows as sys;
 
 #[cfg(not(any(
-    all(target_os = "linux", linker),
+    all(any(target_os = "linux", target_os = "android"), linker),
     target_vendor = "apple",
     target_os = "windows",
 )))]


### PR DESCRIPTION
Almost all android kernel have support for the syscall, but don't have proper wrapper.

This MR also fixes detection of the target os in case of cross compilation